### PR TITLE
add flag to list only suites

### DIFF
--- a/command.go
+++ b/command.go
@@ -54,7 +54,7 @@ func NewCommand(
 	}
 
 	cmdListTests.Flags().BoolP("only-suites", "s", false, "Only list suites")
-	cmdListTests.Flags().StringSliceP("suite", "Z", nil, "Only list suites specified")
+	cmdListTests.Flags().StringSliceP("suite", "Z", nil, "Only list specified suites and their contained tests")
 	cmdListTests.Flags().StringSliceP("id", "i", nil, "Only list tests with the given identifier")
 	cmdListTests.Flags().StringSliceP("tag", "t", nil, "Only list tests with the given tags")
 

--- a/command.go
+++ b/command.go
@@ -53,8 +53,9 @@ func NewCommand(
 		},
 	}
 
-	cmdListTests.Flags().StringSliceP("id", "i", nil, "Only run tests with the given identifier")
-	cmdListTests.Flags().StringSliceP("tag", "t", nil, "Only run tests with the given tags")
+	cmdListTests.Flags().BoolP("only-suites", "s", false, "Only list suites")
+	cmdListTests.Flags().StringSliceP("id", "i", nil, "Only list tests with the given identifier")
+	cmdListTests.Flags().StringSliceP("tag", "t", nil, "Only list tests with the given tags")
 
 	var cmdRunTests = &cobra.Command{
 		Use:           "test",

--- a/command.go
+++ b/command.go
@@ -54,6 +54,7 @@ func NewCommand(
 	}
 
 	cmdListTests.Flags().BoolP("only-suites", "s", false, "Only list suites")
+	cmdListTests.Flags().StringSliceP("suite", "Z", nil, "Only list suites specified")
 	cmdListTests.Flags().StringSliceP("id", "i", nil, "Only list tests with the given identifier")
 	cmdListTests.Flags().StringSliceP("tag", "t", nil, "Only list tests with the given tags")
 

--- a/list.go
+++ b/list.go
@@ -1,9 +1,20 @@
 package barrier
 
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
 func listTests(suites []*suiteInfo) error {
 
+	onlySuites := viper.GetBool("only-suites")
 	for _, suite := range suites {
-		suite.listTests()
+		if onlySuites {
+			fmt.Printf("%s\n", suite)
+		} else {
+			suite.listTests()
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Description
added a flag for the list command to list only suites   `-s, --only-suites   Only list suites`
added this one as well`  -Z, --suite strings   Only list suites specified`


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Want a way to list all suites without seeing all tests. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
