### PR TITLE
collect duration after recover

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -37,14 +37,14 @@ jobs:
           go install github.com/AlekSi/gocov-xml@latest
 
       - name: setup-for-older-go
-        if: ${{ matrix.go <= 1.17 }}
+        if: ${{ matrix.go <= 1.18 }}
         run: |
           # stay on an older version of golangci-lint which still builds against 1.17
           # This is due to the introduction of generics.
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
 
       - name: setup-for-newer-go
-        if: ${{ matrix.go > 1.17 }}
+        if: ${{ matrix.go > 1.18 }}
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 

--- a/printer.go
+++ b/printer.go
@@ -23,8 +23,9 @@ func printSetupError(id, suite, name string, recovery interface{}, err error) {
 	fmt.Printf("%s\n",
 		goterm.Bold(
 			goterm.Color(
-				fmt.Sprintf("%s FAIL %s",
+				fmt.Sprintf("%s: %s FAIL %s",
 					id,
+					suite,
 					name,
 				),
 				goterm.YELLOW,

--- a/runner.go
+++ b/runner.go
@@ -85,6 +85,7 @@ func (r *testRunner) executeIteration(ctx context.Context, currTest testRun, res
 			var data interface{}
 			var td TearDownFunction
 			var err error
+			var start time.Time
 
 			buf := &bytes.Buffer{}
 
@@ -102,6 +103,7 @@ func (r *testRunner) executeIteration(ctx context.Context, currTest testRun, res
 
 				// recover remote code.
 				r := recover()
+				ti.duration = time.Since(start)
 				if r == nil {
 					return
 				}
@@ -144,9 +146,8 @@ func (r *testRunner) executeIteration(ctx context.Context, currTest testRun, res
 				}()
 			}
 
-			start := time.Now()
+			start = time.Now()
 			ti.err = t.test.Function(ctx, subTestInfo)
-			ti.duration = time.Since(start)
 
 		}(currTest, i)
 	}


### PR DESCRIPTION
## Description

Added duration of test result after recover() to account for when a `barrer.Step` fails.

## Motivation and Context

When a `barrier.Step` fails, it panics, which means that this line https://github.com/PaloAltoNetworks/barrier/blob/master/runner.go#LL149C28-L149C29 will be skipped. As a result, when the logs are printed duration will be at its default value (0), thus will look like this `Iteration [1] log after 0s`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
