### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -22,9 +22,9 @@ jobs:
           - "1.20"
           - "1.21"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           go version
           go install github.com/securego/gosec/cmd/gosec@latest
-          go install github.com/axw/gocov/gocov@master
+          go install github.com/axw/gocov/gocov@v1.1.0
           go install github.com/AlekSi/gocov-xml@latest
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
 

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -34,7 +34,7 @@ jobs:
           go install github.com/securego/gosec/cmd/gosec@latest
           go install github.com/axw/gocov/gocov@master
           go install github.com/AlekSi/gocov-xml@latest
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
 
       - name: build
         run: |


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Note:
- Pin go mod to older version so it builds now